### PR TITLE
feat: add wendy-gcp-deployment and github-actions skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -224,6 +224,37 @@
                 "integration-tests",
                 "docker"
             ]
+        },
+        {
+            "name": "wendy-gcp-deployment",
+            "source": "./wendy-gcp-deployment",
+            "description": "Wendy's GCP deployment conventions: Pulumi (Go, GCS backend, KMS secrets), PoLP custom IAM roles, OIDC-only CI auth, wendy.sh/wendy.dev DNS rules, cost-efficiency, and dev/prod splits. Intermediate until the v1 consolidated deployment model.",
+            "category": "development",
+            "keywords": [
+                "gcp",
+                "google-cloud",
+                "pulumi",
+                "iam",
+                "least-privilege",
+                "cloud-run",
+                "dns",
+                "workload-identity-federation",
+                "deployment"
+            ]
+        },
+        {
+            "name": "github-actions",
+            "source": "./github-actions",
+            "description": "GitHub Actions hygiene for any workflow: prefer established actions over hand-rolled scripts, verify action versions at authoring time (never from memory), least-privilege permissions, OIDC-only cloud auth.",
+            "category": "development",
+            "keywords": [
+                "github-actions",
+                "ci",
+                "workflow",
+                "oidc",
+                "permissions",
+                "action-versions"
+            ]
         }
     ]
 }

--- a/github-actions/SKILL.md
+++ b/github-actions/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: github-actions
+description: 'Expert guidance on writing GitHub Actions workflows. Use when: (1) writing or editing any file under .github/workflows/, (2) choosing between an existing action and a shell script in CI, (3) picking action versions, (4) configuring workflow permissions or cloud authentication from CI, (5) reviewing a workflow in a PR.'
+---
+
+# GitHub Actions
+
+Applies to every workflow — deploys, tests, releases, anything under `.github/workflows/`.
+
+## Rule 1: Prefer established actions over hand-rolled scripts
+
+If a mature, maintained action covers the use case, use it. Hand-roll only when no action covers the case — and say so in the PR. Checking out code, docker login/build/push, cloud auth, uploading artifacts, releases: all covered by first-party or vendor actions (`actions/*`, `docker/*`, `google-github-actions/*`, `pulumi/*`).
+
+Maturity check for third-party actions: maintained (recent releases), widely used, ideally from the vendor of the tool. Obscure single-maintainer actions holding credentials are worse than a script.
+
+## Rule 2: Verify versions at authoring time — never from memory
+
+Your memory of "the current major" is stale. Proof, from a real baseline test (2026-07): a model confidently pinned `actions/checkout@v4` and `google-github-actions/auth@v2` as "current majors" — the actual latest were **v7** and **v3**. Every version you remember is a version to verify.
+
+The check takes seconds per action:
+
+```bash
+gh api repos/actions/checkout/releases/latest --jq .tag_name
+```
+
+(or the releases page / marketplace). Do this for **every** action in the workflow you're writing, at the moment you're writing it. Writing a version without having run the check this session is the violation — "it was current last month" doesn't count.
+
+Pin by major tag (`@v7`) normally; pin by commit SHA when supply-chain hygiene demands it (workflows with credentials touching prod).
+
+## Rule 3: Least privilege
+
+- Explicit `permissions:` block on every job: start from `contents: read`, add only what's needed (e.g. `id-token: write` for OIDC).
+- Cloud auth via OIDC federation only — no long-lived cloud secrets in GitHub. For GCP specifically, the wendy-gcp-deployment skill (`references/github-oidc.md`) is the authority; `credentials_json` / SA keys are forbidden, including as a fallback or stopgap.
+- Secrets that must exist in GitHub (e.g. a token for a SaaS with no OIDC) get environment-level scoping, not repo-wide, when environments are in play.
+
+## Quick checklist for any new workflow
+
+- [ ] Every step that could be an established action is one
+- [ ] Every action version verified this session (`gh api .../releases/latest`)
+- [ ] `permissions:` block present and minimal
+- [ ] Cloud auth is OIDC; no `credentials_json`, no key JSON in secrets
+- [ ] `concurrency:` group on deploy workflows (one deploy per ref at a time)
+- [ ] Deploy trigger split: default branch → dev, semver tags (`v*`) → prod
+
+## Rationalizations that don't fly
+
+| Excuse | Reality |
+|---|---|
+| "v4 is what I've always used" | That's the definition of answering from memory. Run the check. |
+| "The major version barely matters" | Old majors lose runner compatibility and security fixes; some are deprecated outright. |
+| "I'll leave a TODO to bump versions" | The TODO ships. Verify now — it's one command per action. |
+| "A curl in a run: block is simpler than learning the action" | The action handles auth, retries, and edge cases the curl doesn't. Simpler today, pager duty later. |
+| "credentials_json just until WIF is set up" | Keys outlive intentions. WIF bootstrap takes minutes; do it first. |

--- a/wendy-gcp-deployment/SKILL.md
+++ b/wendy-gcp-deployment/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: wendy-gcp-deployment
+description: 'Expert guidance on deploying Wendy applications and infrastructure to Google Cloud. Use when: (1) deploying anything to GCP, (2) writing or changing Pulumi programs, (3) creating GCP service accounts, IAM roles, or custom roles, (4) touching wendy.sh / wendy.dev DNS records, (5) choosing GCP compute or databases, (6) setting up CI/CD deployment to GCP, (7) provisioning Cloud Run, Cloud SQL, or Artifact Registry.'
+references:
+  - references/cost.md
+  - references/iam-polp.md
+  - references/dns.md
+  - references/github-oidc.md
+  - references/pulumi.md
+---
+
+# Wendy GCP Deployment
+
+How Wendy deploys to Google Cloud. **Status: intermediate.** These conventions hold until v1 of the stack runs and the compute workload is consolidated (possibly k8s/GitOps later). The methodology (Pulumi, OIDC, PoLP) is expected to survive that transition; specific names may not.
+
+## Hard rules (non-negotiable)
+
+1. **Requirements before infrastructure.** Never design infra without asking the user about the app's requirements first (see interview below). Never invent project names, regions, or scale assumptions.
+2. **Cost-consciousness is a MUST**, not a preference. Read `references/cost.md` before choosing compute or a database.
+3. **PoLP via custom IAM roles.** Prefer a custom role with the exact permissions needed over any predefined broad role. Needing to alter one DNS record never justifies `roles/dns.admin`. See `references/iam-polp.md`.
+4. **No service account keys. Ever.** CI authenticates via GitHub OIDC / Workload Identity Federation (`references/github-oidc.md`); workloads use attached service accounts. If you are about to write `credentials_json`, export a key, or suggest one "as a stopgap" — stop; that path does not exist here.
+5. **No GCP credentials client-side.** Frontends, device apps, anything running outside Wendy's server perimeter never holds GCP credentials of any form. Devices get mediated access via server-side proxies minting short-lived downscoped credentials (wendy-proxy pattern). Authority: the AAA contract, `/home/sem/wendy/aaa-contract-*.md` (read the latest version when touching auth between services).
+6. **dev/prod split by default.** Default branch deploys to dev; semver tags (`v*`) deploy to prod. Skip the split only with a stated good reason. Both live in the same GCP project for now, split by resource naming (`-dev` / `-prod` suffixes).
+7. **Never clash with pre-existing resources.** Check before creating — especially DNS records (`references/dns.md`) and anything in shared projects.
+
+## Requirements interview (always first)
+
+Before proposing any design, ask the user (don't assume):
+
+- Traffic shape and volume; public or internal?
+- State: does it truly need a database? What kind/size?
+- Latency and availability requirements (is scale-to-zero cold start acceptable?)
+- Which project does it belong in (see map below)? Dev/prod needed?
+- Anything that must survive redeploys (volumes, IPs, data)?
+
+Shape the design to the answers. When requirements are modest, the infrastructure must be too.
+
+## Project map (current truth — verify with `gcloud projects list` if in doubt)
+
+| Project | Purpose |
+|---|---|
+| `wendy-customer` | All customer-facing apps (apps not part of the cloud stack). Per-app isolation inside this project matters: own SA, own custom role, own resources per app. |
+| `wendy-auth` | wendy-auth |
+| `wendy-pki-secure` | pki-core engine |
+| `wendy-pki-services` | pki-core frontends |
+| `cloud-c7e56` | SaaS cloud stack; hosts the `*.wendy.sh` and `*.wendy.dev` DNS zones |
+
+Default region: **`us-central1`** (current home; movable given a real use case — ask, don't switch unilaterally).
+
+## Compute selection
+
+- **Cloud Run first.** Scale-to-zero, request-based billing, no OS to maintain. Default for services and jobs.
+- **VMs are leaned against**, for one specific reason: once spun up, nobody maintains the OS. A VM is acceptable **only** if the OS is completely maintenance-free (e.g. Container-Optimized OS with automated updates, MIGs with automated image rotation). If the plan involves a human ever SSHing in to patch it, it's not an option.
+- **Databases:** the cheapest thing that meets requirements. Read `references/cost.md` — it exists because of a real incident (expensive Cloud SQL clusters provisioned for apps that didn't need them).
+
+## Deployment workflow
+
+1. Requirements interview (above).
+2. Design: compute, data, IAM (custom roles per `references/iam-polp.md`), DNS (`references/dns.md`), dev/prod stacks.
+3. Bootstrap privileged resources (deploy SA, custom role, WIF binding) via the human's own gcloud, with their approval per command. If the human lacks permission: produce the exact commands + a use-case writeup to hand to an admin (template in `references/iam-polp.md`).
+4. Pulumi program — Go preferred, GCS state backend, KMS secrets provider, conventions in `references/pulumi.md`.
+5. GitHub Actions workflow — OIDC only, per `references/github-oidc.md`. Also invoke the `github-actions` skill when writing the workflow.
+
+## Rationalizations that don't fly
+
+| Excuse | Reality |
+|---|---|
+| "roles/dns.admin scoped to the zone is minimal enough" | Cloud DNS supports per-RRset IAM conditions. Zone-wide admin is not the floor; the exact records are. |
+| "A predefined role is simpler than a custom role" | Simpler to type, larger to breach. Custom roles are a one-time cost; see the recipe. |
+| "credentials_json just to get it working" | A leaked key is a standing credential. WIF setup takes minutes; there is no keys-temporarily path. |
+| "It'll need Cloud SQL HA when it grows" | Provision for today's requirements. Growth is a config change, not a sunk cost. |
+| "Skipping dev, it's a small app" | Small apps get semver-tagged prod deploys too. Skipping the split is a decision the user makes, with a reason. |
+| "The zone probably has no record with this name" | `gcloud dns record-sets list` takes two seconds. Check. |
+
+## Red flags — stop and reconsider
+
+- You wrote `roles/*.admin` for a deploy SA
+- You wrote `credentials_json` or `gcloud iam service-accounts keys create`
+- A GCP credential (of any form) ends up in frontend code, a device image, or an app config shipped outside Wendy's servers
+- You picked a region, tier, or project name the user never confirmed
+- Your design has no `-dev` stack and the user never said why
+- You're about to create a DNS record without listing existing ones first

--- a/wendy-gcp-deployment/references/cost.md
+++ b/wendy-gcp-deployment/references/cost.md
@@ -1,0 +1,34 @@
+# Cost-efficiency rules
+
+Cost-consciousness is a MUST. The bill is reviewed; over-provisioning is treated as a defect.
+
+## Cloud Run posture (default for low/moderate traffic)
+
+- `min-instances = 0` (scale-to-zero is Cloud Run's default — keep it unless cold starts violate a stated requirement).
+- Request-based billing (default): CPU allocated only while serving; idle costs nothing.
+- Modest limits by default: 1 vCPU / 512 MiB unless the app demonstrably needs more.
+- `max-instances` low (e.g. 2–5) for internal tools, so a bug can't fan out into a big bill.
+
+## Database decision ladder (walk it top-down, stop at the first fit)
+
+1. **No database.** Can state live in the client, a file, or be recomputed? Many dashboards/tools need no DB.
+2. **SQLite on a volume / GCS.** Single-writer, small data, internal tool → a mounted volume or GCS object is fine.
+3. **Firestore.** Serverless, scales to zero cost on no traffic, generous free tier. Good for key-value/document state.
+4. **Cloud SQL Postgres, smallest tier, zonal.** `db-f1-micro` (~$8–10/mo) or `db-g1-small`. `availabilityType: ZONAL` (no HA), 10 GB disk, backups on, PITR off. Shared-core tiers have no SLA — that is acceptable for dev and internal tools, and for many small prod apps.
+5. **Bigger Cloud SQL / HA.** Only with a stated requirement (SLA, load, compliance). HA roughly doubles cost.
+
+**Never** default to: HA/regional Cloud SQL, dedicated-core tiers, read replicas, or AlloyDB (no permanent free tier; entry cost far above shared-core Cloud SQL) — unless requirements demand them.
+
+> Real incident this section exists for: apps that needed a small history table were given full Cloud SQL clusters. The requirement was step 2–4 on the ladder; the bill said otherwise.
+
+## Other recurring-cost traps
+
+- **Global external ALB:** the forwarding rule alone has a fixed monthly cost (order of ~$20/mo) before traffic. For a small internal service, consider Cloud Run domain mapping (free, but requires one-time domain verification and is region-constrained) or IAP on Cloud Run directly. Present the tradeoff; let the user pick.
+- **Static IPs** reserved but unattached bill hourly.
+- **VPC connectors, NAT gateways:** standing hourly cost. Avoid needing them (public-IP Cloud SQL via the connector/auth-proxy path needs no VPC connector).
+- **Artifact Registry:** storage billed per GiB — set a cleanup policy (keep last N versions) on repos with frequent pushes.
+- **Idle dev environments:** dev stacks should scale to zero. A dev environment with `min-instances: 1` or a dedicated-core dev database is a bug.
+
+## Rule of thumb
+
+Estimate the monthly cost of what you're about to provision and say it out loud in the design ("~$X/mo"). If you can't estimate it, look up current pricing — never guess from memory. Anything over ~$25/mo for an internal/low-traffic app needs an explicit justification tied to a requirement the user stated.

--- a/wendy-gcp-deployment/references/dns.md
+++ b/wendy-gcp-deployment/references/dns.md
@@ -1,0 +1,57 @@
+# DNS — wendy.sh / wendy.dev
+
+The `*.wendy.sh` and `*.wendy.dev` managed zones live in the cloud project (`cloud-c7e56`) — always. Apps in other projects that need records reach across projects with a narrowly-scoped identity; the zones never move.
+
+## Rules
+
+1. **Never clash with pre-existing records.** Before creating anything:
+   ```bash
+   gcloud dns record-sets list --zone=<zone> --project=cloud-c7e56 --filter="name~<name>"
+   ```
+   If the name exists, stop and surface it to the user — never overwrite, never import someone else's record into your stack.
+2. **Access is per-record, not per-zone.** Grant the deploy identity a custom role restricted with an IAM condition to exactly the records the app owns.
+3. Pulumi manages records via a second explicit provider pointed at `cloud-c7e56`.
+
+## Narrowest grant (verified against Cloud DNS docs, 2026-07)
+
+Cloud DNS supports **zone-level IAM** (`gcloud dns managed-zones set-iam-policy`) and **per-RRset IAM conditions**. Resource name format for conditions:
+
+```
+projects/cloud-c7e56/managedZones/<zone>/rrsets/<domain>./<TYPE>   # note trailing dot
+```
+
+Custom role permissions for managing records:
+
+- Mutations need BOTH: `dns.changes.create` AND `dns.resourceRecordSets.create` / `.update` / `.delete`
+- Reads: `dns.resourceRecordSets.get`, `dns.resourceRecordSets.list`, `dns.changes.get`, `dns.managedZones.get`
+
+**Caveat from the docs:** `dns.changes.create` cannot be usefully constrained by an RRset condition — grant it (and the reads) in an unconditional binding on the managed zone, and put the RRset condition on the binding that carries create/update/delete. Under very restrictive conditions `list`/`get` can fail; transactional edits may need `--skip-soa-update`.
+
+Example condition (CEL) for an app owning `status.wendy.sh`:
+
+```
+resource.name.endsWith('/rrsets/status.wendy.sh./A') ||
+resource.name.endsWith('/rrsets/status.wendy.sh./TXT')
+```
+
+(Use `resource.name.extract('/rrsets/{name}/').endsWith('.status.wendy.sh.')` style for a subtree.)
+
+**Note:** zone-level IAM policies may reject federated (`principalSet://`) members — test during bootstrap; if rejected, this is a legitimate case for a deploy SA + impersonation (see `github-oidc.md`).
+
+## Pulumi cross-project record (Go)
+
+```go
+dnsProvider, err := gcp.NewProvider(ctx, "dns", &gcp.ProviderArgs{
+    Project: pulumi.String("cloud-c7e56"),
+})
+// ...
+_, err = dns.NewRecordSet(ctx, "status-a", &dns.RecordSetArgs{
+    ManagedZone: pulumi.String("<zone-name>"), // verify actual zone name first
+    Name:        pulumi.String("status.wendy.sh."),
+    Type:        pulumi.String("A"),
+    Ttl:         pulumi.Int(300),
+    Rrdatas:     pulumi.StringArray{ip.Address},
+}, pulumi.Provider(dnsProvider))
+```
+
+Verify the actual managed-zone names in `cloud-c7e56` (`gcloud dns managed-zones list --project=cloud-c7e56`) — don't assume `wendy-sh`/`wendy-dev`.

--- a/wendy-gcp-deployment/references/github-oidc.md
+++ b/wendy-gcp-deployment/references/github-oidc.md
@@ -1,0 +1,53 @@
+# GitHub Actions → GCP via OIDC (Workload Identity Federation)
+
+Mandatory for all CI deploys. There is no service-account-key path — `credentials_json`, `gcloud iam service-accounts keys create`, and JSON keys in repo secrets are forbidden, including "temporarily".
+
+## Two modes (per google-github-actions/auth README)
+
+- **Direct WIF (preferred, Google's current recommendation):** the workload identity pool principal gets IAM bindings directly on resources; no intermediate service account exists at all. Configure `auth` with `project_id` + `workload_identity_provider` only.
+- **SA impersonation:** add `service_account:`. Use only where an API rejects federated principals (some do — Cloud DNS zone-level policies are a suspect; test during bootstrap).
+
+## Bootstrap (once per repo, via the human's gcloud — see iam-polp.md)
+
+```bash
+gcloud iam workload-identity-pools create github \
+  --project=<project> --location=global
+
+gcloud iam workload-identity-pools providers create-oidc github-actions \
+  --project=<project> --location=global --workload-identity-pool=github \
+  --issuer-uri="https://token.actions.githubusercontent.com/" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository == '<org>/<repo>'"
+```
+
+**The attribute condition is required, not optional** — GitHub is a shared issuer across all of github.com; without the condition, any repo on GitHub whose claims you map could try to enter the pool. Scope it to the exact repo (tighten further with `assertion.ref` for prod-only pools if wanted).
+
+Bindings then go to:
+
+```
+principalSet://iam.googleapis.com/projects/<num>/locations/global/workloadIdentityPools/github/attribute.repository/<org>/<repo>
+```
+
+## Workflow side
+
+```yaml
+permissions:
+  contents: read
+  id-token: write   # required for OIDC
+
+steps:
+  - uses: google-github-actions/auth@v3   # v3 verified latest 2026-07 — re-verify when authoring
+    with:
+      project_id: <project>
+      workload_identity_provider: projects/<num>/locations/global/workloadIdentityPools/github/providers/github-actions
+```
+
+For Pulumi state on GCS and gcpkms secrets, this same auth provides Application Default Credentials — nothing extra needed.
+
+Version note: verify current action versions at authoring time (see the `github-actions` skill) — the tags above were verified 2026-07 and will age.
+
+## dev/prod in the workflow
+
+- Push to default branch → deploy `dev` stack.
+- Semver tag `v*` → deploy `prod` stack.
+- One WIF binding per repo is fine for both; if prod needs stronger control, a second pool/provider with `assertion.ref == 'refs/tags/...'`-style conditions is the mechanism.

--- a/wendy-gcp-deployment/references/iam-polp.md
+++ b/wendy-gcp-deployment/references/iam-polp.md
@@ -1,0 +1,61 @@
+# IAM — Principle of Least Privilege
+
+Every app gets its own deploy identity with the smallest permission set that makes its `pulumi up` succeed. Broad predefined roles (`roles/run.admin`, `roles/cloudsql.admin`, `roles/secretmanager.admin`, `roles/dns.admin`, any `*.admin`) are not the floor — the exact permission list is.
+
+## The recipe
+
+1. **List what the stack actually manages.** From the Pulumi program: which resource types are created/updated/read?
+2. **Derive the exact permissions.** Check the GCP docs for the permissions each operation needs (don't guess from memory — permission strings change). E.g. deploying a Cloud Run revision needs `run.services.get/update`, not all of `run.*`.
+3. **Create a custom role per app** (or per app+concern when one app spans projects):
+
+```bash
+gcloud iam roles create wendyStatusDeploy \
+  --project=wendy-customer \
+  --title="wendy-status deploy" \
+  --permissions=run.services.get,run.services.update,run.revisions.get,... \
+  --stage=GA
+```
+
+4. **Bind it as narrowly as the resource supports**: resource-level IAM (a zone, a secret, a bucket, a KMS key, a service account) beats project-level. Add IAM conditions where the service supports them (DNS record sets do — see `dns.md`).
+5. **Iterate by failure, not by inflation.** When `pulumi up` fails with a missing permission, add that one permission to the custom role. Never "fix" a permission error by swapping in a predefined admin role.
+
+## Standard identities per app
+
+- **Deploy identity** — used by CI via WIF (see `github-oidc.md`). Prefer **Direct WIF** (the `principalSet://` from the workload identity pool gets the IAM bindings directly — no service account at all). Where an API rejects federated principals, fall back to a dedicated deploy SA + impersonation.
+- **Runtime SA** — one per app (`<app>-run@...`), attached to the Cloud Run service/VM. Gets only what the app needs at runtime (e.g. `roles/cloudsql.client`, `secretmanager.secretAccessor` **on the specific secret**). Never the default compute SA.
+- `roles/iam.serviceAccountUser` for the deployer is granted **on the runtime SA resource**, never project-wide.
+
+Per-app isolation in `wendy-customer` is deliberate: one app's deploy identity must not be able to touch another app's resources.
+
+## Known-good narrow grants
+
+| Need | Grant |
+|---|---|
+| Push images | `roles/artifactregistry.writer` on the specific repository |
+| Read one secret at runtime | `roles/secretmanager.secretAccessor` on that secret |
+| Pulumi state | `roles/storage.objectAdmin` on the state bucket only |
+| Pulumi secrets (gcpkms) | `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the specific CryptoKey (lowest grantable level) |
+| Deploy acting as runtime SA | `roles/iam.serviceAccountUser` on that SA |
+| DNS records | custom role + per-RRset condition — see `dns.md` |
+
+## Bootstrap flow (privileged setup)
+
+Creating custom roles, SAs, WIF pools/bindings requires privileges the deploy identity must never hold. Flow:
+
+1. Do it via **the human's own gcloud credentials**, locally, with the user approving each privileged command. Enable required APIs here too (`gcloud services enable ...`) — the pipeline never gets `serviceusage` permissions.
+2. **If the human lacks permissions**, don't escalate creatively. Produce an admin handoff:
+
+```markdown
+## IAM bootstrap request: <app>
+**Use case:** <one paragraph: what the app is, where it deploys, what CI needs to manage>
+**Requested by:** <human> for repo <org/repo>
+**Commands** (run by someone with iam.roles.create / iam.serviceAccounts.create / WIF admin):
+<the exact gcloud commands, ready to paste>
+**Resulting blast radius:** <what this identity can and cannot touch>
+```
+
+## Self-check before finishing any IAM design
+
+- Does any binding contain `*.admin`? Justify it or replace it.
+- Is every grant on the narrowest resource the service supports?
+- Could this app's deploy identity affect a sibling app? If yes in `wendy-customer`, redesign.

--- a/wendy-gcp-deployment/references/pulumi.md
+++ b/wendy-gcp-deployment/references/pulumi.md
@@ -1,0 +1,30 @@
+# Pulumi conventions
+
+- **Language: Go preferred.** Other languages acceptable when there's a reason (existing codebase, team familiarity) — say the reason.
+- **State backend: GCS.** `pulumi login gs://<state-bucket>` — uses Application Default Credentials. One bucket per project (or per team), deploy identity gets `roles/storage.objectAdmin` on that bucket only.
+- **Secrets provider: gcpkms**, never passphrase:
+
+```bash
+pulumi stack init dev \
+  --secrets-provider="gcpkms://projects/<project>/locations/<loc>/keyRings/<ring>/cryptoKeys/<key>"
+```
+
+Key purpose must be `ENCRYPT_DECRYPT`; deploy identity needs `roles/cloudkms.cryptoKeyEncrypterDecrypter` on that CryptoKey. Existing stacks migrate with `pulumi stack change-secrets-provider`.
+
+- **Runtime app secrets** live in Secret Manager (created by Pulumi, read by the runtime SA) — Pulumi config secrets are for deploy-time values only.
+
+## Stacks & naming
+
+- Two stacks per app: `dev` and `prod`. Same GCP project (for now), split by naming: every resource name carries the stack, e.g. `wendy-status-dev`. Use `ctx.Stack()` in names rather than hardcoding.
+- Config per stack (`Pulumi.dev.yaml` / `Pulumi.prod.yaml`): image tag, sizing, min-instances. Prod and dev must differ only by config, never by code paths.
+- Image tags: dev deploys `sha-<short>`, prod deploys the semver tag — prod is always traceable to a release.
+
+## Safety rules
+
+- **Never clash with pre-existing resources.** Before `pulumi up` on a new stack in a shared project, list what already exists (especially DNS — see `dns.md`, and anything named similarly in `wendy-customer`). If a resource already exists outside the stack, surface it — adopt via `pulumi import` only when the user confirms the stack should own it.
+- **Stateful resources get protection:** `pulumi.Protect(true)` and provider-level deletion protection (e.g. `DeletionProtection: true` on Cloud SQL) on databases, buckets with data, and anything holding state. A `pulumi destroy` of a dev stack must never be able to take customer data with it.
+- `pulumi preview` runs on PRs; `pulumi up` only from the deploy workflow (default branch → dev, tag → prod). No `up` from laptops against prod except during initial bootstrap.
+
+## CI integration
+
+Use `pulumi/actions` (verify current version at authoring time — v7 as of 2026-07; there is also `pulumi/auth-actions` for Pulumi Cloud OIDC, not needed with the GCS backend). Env for GCS backend: `PULUMI_BACKEND_URL: gs://<bucket>` avoids a login step. The google-github-actions/auth step (see `github-oidc.md`) supplies ADC for state, KMS, and the GCP provider in one go.


### PR DESCRIPTION
## Summary

Two new skills guiding coworker Claude instances on GCP deployments. These are **intermediates** until v1 of the stack runs and the compute workload is consolidated.

### `wendy-gcp-deployment`
- Hard rules: requirements interview before any design, cost-consciousness as a MUST, PoLP via custom IAM roles, no SA keys ever, no GCP credentials client-side (AAA contract), dev/prod split by default (default branch → dev, semver tags → prod), never clash with pre-existing resources.
- Project map hardcoded (`wendy-customer`, `wendy-auth`, `wendy-pki-secure`, `wendy-pki-services`, `cloud-c7e56`), default region `us-central1`.
- References: cost rules (database decision ladder, Cloud Run posture), IAM/PoLP recipe (custom roles, Direct WIF, admin-handoff template), DNS (per-RRset IAM conditions for wendy.sh/wendy.dev zones in `cloud-c7e56`), GitHub OIDC/WIF setup, Pulumi conventions (Go, GCS backend, gcpkms secrets).

### `github-actions`
- Applies to any workflow: prefer established actions over hand-rolled scripts, verify action versions at authoring time (never memory), minimal `permissions:`, OIDC-only cloud auth.

## Validation

TDD per the writing-skills process: baseline subagents **without** the skills reproduced the real-world failures (stale action versions asserted as current — claimed checkout@v4/auth@v2, actual latest v7/v3; `credentials_json` offered as a stopgap; zone-wide `dns.admin`; broad predefined roles; invented region; no dev/prod split). With the skills in context, both scenarios flipped on every documented failure and surfaced no new rationalizations.

All external facts (action versions, Cloud DNS per-RRset IAM condition support, Pulumi GCS/KMS syntax, WIF attribute-condition requirement) verified against live docs on 2026-07-28.